### PR TITLE
Invalidate cache when master branche change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,9 @@ RUN COMPOSER_ALLOW_SUPERUSER=1 \
     COMPOSER_HOME="/composer" \
     composer global config minimum-stability dev
 
+# This line invalidates cache when master branch change
+ADD https://github.com/vimeo/psalm/commits/master.atom /dev/null
+
 RUN COMPOSER_ALLOW_SUPERUSER=1 \
     COMPOSER_HOME="/composer" \
     composer global require --prefer-dist --no-progress --dev vimeo/psalm


### PR DESCRIPTION
fixes #10 By using "ADD url" trick to invalidate cache.

The URL is called on every build, but cache is used only when the reponses returned by the URL is identical to the previous build.

Didn't used api endpoint dues to rate limite
Didn't used http web page, because contains random chars that change on each request (and prevent use of cache when nothing change)