### PR TITLE
Fix passing composer_ignore_platform_reqs value

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,7 @@ fi
 
 if test -f "composer.json"; then
     IGNORE_PLATFORM_REQS=""
-    if [ "$CHECK_PLATFORM_REQUIREMENTS" = "false" ] || [ "$INPUT_COMPOSER_CHECK_PLATFORM_REQUIREMENTS" = "false" ]; then
+    if [ "$CHECK_PLATFORM_REQUIREMENTS" = "false" ] || [ "$INPUT_COMPOSER_IGNORE_PLATFORM_REQS" = "false" ]; then
         IGNORE_PLATFORM_REQS="--ignore-platform-reqs"
     fi
 


### PR DESCRIPTION
Github Actions input values are passed as env vars in form of capital name prefixed with `$INPUT_`.

The input name is `composer_ignore_platform_reqs`, therefore the passed env is `$INPUT_COMPOSER_IGNORE_PLATFORM_REQS`. 

Not `INPUT_COMPOSER_CHECK_PLATFORM_REQUIREMENTS`