### PR TITLE
Wrong condition for ignore platform reqs

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,7 @@ fi
 
 if test -f "composer.json"; then
     IGNORE_PLATFORM_REQS=""
-    if [ "$CHECK_PLATFORM_REQUIREMENTS" = "false" ] || [ "$INPUT_COMPOSER_IGNORE_PLATFORM_REQS" = "false" ]; then
+    if [ "$CHECK_PLATFORM_REQUIREMENTS" = "false" ] || [ "$INPUT_COMPOSER_IGNORE_PLATFORM_REQS" = "true" ]; then
         IGNORE_PLATFORM_REQS="--ignore-platform-reqs"
     fi
 


### PR DESCRIPTION
If I want to set the composer `--ignore-platform-reqs` I'm supposed to use the `composer_ignore_platform_reqs` action param.
`composer_ignore_platform_reqs` should be set to `true` if I'd like to append `--ignore-platform-reqs` to the composer command.