### PR TITLE
Fixes issue where relative_dir doesn't work

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,9 @@ inputs:
   ssh_domain:
     description: The domain to gather SSH public keys for (automatic for github.com, gitlab.com, bitbucket.org)
     required: false
+  relative_dir:
+    description: If your composer file is not in the directory, you can specify the relative directory.
+    required: false
 
 
 runs:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,7 @@ if [ ! -z "$INPUT_REPORT_FILE" ]; then
 fi
 
 SHOW_INFO=""
-if [ "$INPUT_SHOW_INFO" = "true"]; then
+if [ "$INPUT_SHOW_INFO" = "true" ]; then
   SHOW_INFO="--show-info=true"
 fi
 


### PR DESCRIPTION
Fixes this issue https://github.com/psalm/psalm-github-actions/issues/53

Additionally, the script was giving me the error `sh: missing ]`. Adding a missing space fixes the issue. See https://www.shellcheck.net/wiki/SC1020 for more info. 