### PR TITLE
Add PHP version as optional action input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,10 @@ inputs:
   relative_dir:
     description: If your composer file is not in the directory, you can specify the relative directory.
     required: false
-
+  php_version:
+    description: The PHP version to run Psalm against
+    required: false
+    default: ''
 
 runs:
   using: 'docker'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,6 +16,11 @@ if [ "$INPUT_SHOW_INFO" = "true" ]; then
   SHOW_INFO="--show-info=true"
 fi
 
+PHP_VERSION=""
+if [ -n "$INPUT_PHP_VERSION" ]; then
+  PHP_VERSION="--php-version=$INPUT_PHP_VERSION"
+fi
+
 if [ -n "$INPUT_SSH_KEY" ]
 then
     echo "::group::Keys setup for private repositories"
@@ -81,4 +86,4 @@ else
 fi
 
 /composer/vendor/bin/psalm --version
-/composer/vendor/bin/psalm --output-format=github $TAINT_ANALYSIS $REPORT $SHOW_INFO $*
+/composer/vendor/bin/psalm --output-format=github $TAINT_ANALYSIS $REPORT $SHOW_INFO $PHP_VERSION $*


### PR DESCRIPTION
Psalm allows us to specify the PHP version it analyzes code against. Exposing this option allows users of this action to supply a matrix of PHP options to enable Psalm runs against each of the PHP versions they would like to support, or just to analyze against a specific version of PHP that differs from the container's installed version.

This provides a partial solution for #60, as the container-installed PHP version would no longer limit the versions Psalm could analyze against.